### PR TITLE
Set Leveling#getLeaderboard optional parameters as optional

### DIFF
--- a/src/handlers/Leveling.ts
+++ b/src/handlers/Leveling.ts
@@ -4,8 +4,8 @@ import { BaseHandler } from "./BaseHandler"
 export class Leveling extends BaseHandler {
 	async getLeaderboard(
 		guildId: string,
-		start: number | undefined,
-		end: number | undefined
+		start?: number,
+		end?: number
 	) {
 		if (start !== undefined && start < 0) {
 			throw new Error("Start parameter must be non-negative")

--- a/src/handlers/Leveling.ts
+++ b/src/handlers/Leveling.ts
@@ -2,11 +2,7 @@ import type { Leaderboard, LevelData, SuccessResponse } from "../types"
 import { BaseHandler } from "./BaseHandler"
 
 export class Leveling extends BaseHandler {
-	async getLeaderboard(
-		guildId: string,
-		start?: number,
-		end?: number
-	) {
+	async getLeaderboard(guildId: string, start?: number, end?: number) {
 		if (start !== undefined && start < 0) {
 			throw new Error("Start parameter must be non-negative")
 		}


### PR DESCRIPTION
Otherwise, it's required to put (undefined, undefined)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of optional parameters for leaderboard retrieval. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->